### PR TITLE
fix: update m.np.playstation tld

### DIFF
--- a/src/search/SEARCH_BASE_URL.ts
+++ b/src/search/SEARCH_BASE_URL.ts
@@ -1,1 +1,1 @@
-export const SEARCH_BASE_URL = "https://m.np.playstation.net/api/search";
+export const SEARCH_BASE_URL = "https://m.np.playstation.com/api/search";

--- a/src/user/USER_BASE_URL.ts
+++ b/src/user/USER_BASE_URL.ts
@@ -1,2 +1,2 @@
 export const USER_BASE_URL =
-  "https://m.np.playstation.net/api/userProfile/v1/internal/users";
+  "https://m.np.playstation.com/api/userProfile/v1/internal/users";

--- a/src/user/getProfileFromAccountId.test.ts
+++ b/src/user/getProfileFromAccountId.test.ts
@@ -43,7 +43,7 @@ describe("Function: getProfileFromUserName", () => {
 
     server.use(
       rest.get(
-        "https://m.np.playstation.net/api/userProfile/v1/internal/users/111222333444/profiles",
+        "https://m.np.playstation.com/api/userProfile/v1/internal/users/111222333444/profiles",
         (_, res, ctx) => {
           return res(ctx.json(mockResponse));
         }
@@ -72,7 +72,7 @@ describe("Function: getProfileFromUserName", () => {
 
     server.use(
       rest.get(
-        "https://m.np.playstation.net/api/userProfile/v1/internal/users/111222333444/profiles",
+        "https://m.np.playstation.com/api/userProfile/v1/internal/users/111222333444/profiles",
         (_, res, ctx) => {
           return res(ctx.json(mockResponse));
         }

--- a/src/user/getUserFriendsAccountIds.test.ts
+++ b/src/user/getUserFriendsAccountIds.test.ts
@@ -33,7 +33,7 @@ describe("Function: getUserFriendsAccountIds", () => {
 
     server.use(
       rest.get(
-        "https://m.np.playstation.net/api/userProfile/v1/internal/users/me/friends",
+        "https://m.np.playstation.com/api/userProfile/v1/internal/users/me/friends",
         (_, res, ctx) => {
           return res(ctx.json(mockResponse));
         }
@@ -63,7 +63,7 @@ describe("Function: getUserFriendsAccountIds", () => {
 
     server.use(
       rest.get(
-        "https://m.np.playstation.net/api/userProfile/v1/internal/users/111222333444/friends",
+        "https://m.np.playstation.com/api/userProfile/v1/internal/users/111222333444/friends",
         (_, res, ctx) => {
           return res(ctx.json(mockResponse));
         }


### PR DESCRIPTION
Sony changed the top-level domain affecting three functions in the library:
* `makeUniversalSearch()`
* `getProfileFromAccountId()`
* `getUserFriendsAccountIds()`

The fix in this commit is required for these functions to work properly as of today.