### PR TITLE
fix: add type declaration to package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
   "exports": {
     ".": {
       "require": "./dist/index.js",
-      "import": "./dist/psn-api.esm.js"
+      "import": "./dist/psn-api.esm.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "author": "Wes Copeland",


### PR DESCRIPTION
Resolves [#145](https://github.com/achievements-app/psn-api/issues/145)

I tested changes locally with `npm link`. Everything works fine.

### Explanation from ChatGPT ¯\_(ツ)_/¯

> Adding types to package.json exports helps typescript find the type declarations of your package.
> 
> Before you added the "types" field to your "exports", TypeScript couldn’t find your type declarations through the "exports" field. But when you set moduleResolution to "node", TypeScript fell back to looking for an index.d.ts file in your module’s root directory. Since your type declarations were there, TypeScript was able to find them, and you didn’t see any error.
> 
> However, it’s generally better to specify all your module’s entry points (including type declarations) in the "exports" field. This way, you’re not relying on TypeScript’s fallback behavior, which might not work in all environments or future versions of TypeScript. Plus, it makes your package’s interface clearer to other developers. That’s why adding "types": "./dist/index.d.ts" to your package.json is a good solution.