### PR TITLE
fix: alias exchangeNpssoForCode to exchangeNpssoForAccessCode

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ If you see an error response, try using different browser.
 const myNpsso = "<64 character token>";
 
 // We'll exchange your NPSSO for a special access code.
-const accessCode = await exchangeNpssoForCode(myNpsso);
+const accessCode = await exchangeNpssoForAccessCode(myNpsso);
 
 // We can use the access code to get your access token and refresh token.
 const authorization = await exchangeCodeForAccessToken(accessCode);
@@ -108,7 +108,7 @@ Click the function names to open their complete docs on the docs site.
 ### Authentication
 
 - [`exchangeCodeForAccessToken()`](https://psn-api.achievements.app/api-docs/authentication#exchangecodeforaccesstoken) - Exchange your access code for access and refresh tokens.
-- [`exchangeNpssoForCode()`](https://psn-api.achievements.app/api-docs/authentication#exchangenpssoforcode) - Exchange your NPSSO for an access code.
+- [`exchangeNpssoForAccessCode()`](https://psn-api.achievements.app/api-docs/authentication#exchangenpssoforaccesscode) - Exchange your NPSSO for an access code.
 - [`exchangeRefreshTokenForAuthTokens()`](https://psn-api.achievements.app/api-docs/authentication#exchangerefreshtokenforauthtokens) - Get a new access token using your refresh token (bypassing the need to constantly auth with your NPSSO).
 
 ### Search

--- a/src/__playground.ts
+++ b/src/__playground.ts
@@ -18,7 +18,7 @@
  */
 import {
   exchangeCodeForAccessToken,
-  exchangeNpssoForCode,
+  exchangeNpssoForAccessCode,
   getUserTitles
 } from "./index";
 
@@ -36,7 +36,7 @@ async function main() {
     );
   }
 
-  const accessCode = await exchangeNpssoForCode(myNpsso);
+  const accessCode = await exchangeNpssoForAccessCode(myNpsso);
   const authorization = await exchangeCodeForAccessToken(accessCode);
 
   const userTitlesResponse = await getUserTitles(

--- a/src/authenticate/exchangeCodeForAccessToken.ts
+++ b/src/authenticate/exchangeCodeForAccessToken.ts
@@ -4,7 +4,7 @@ import type { AuthTokensResponse } from "../models";
 import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
 
 /**
- * @param accessCode Your access code, typically retrieved by using `exchangeNpssoForCode()`.
+ * @param accessCode Your access code, typically retrieved by using `exchangeNpssoForAccessCode()`.
  * @returns An object containing an access token, refresh token, and expiry times for both.
  */
 export const exchangeCodeForAccessToken = async (

--- a/src/authenticate/exchangeNpssoForAccessCode.test.ts
+++ b/src/authenticate/exchangeNpssoForAccessCode.test.ts
@@ -2,11 +2,11 @@ import { rest } from "msw";
 import { setupServer } from "msw/node";
 
 import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
-import { exchangeNpssoForCode } from "./exchangeNpssoForCode";
+import { exchangeNpssoForAccessCode } from "./exchangeNpssoForAccessCode";
 
 const server = setupServer();
 
-describe("Function: exchangeNpssoForCode", () => {
+describe("Function: exchangeNpssoForAccessCode", () => {
   // MSW Setup
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
@@ -14,7 +14,7 @@ describe("Function: exchangeNpssoForCode", () => {
 
   it("is defined #sanity", () => {
     // ASSERT
-    expect(exchangeNpssoForCode).toBeDefined();
+    expect(exchangeNpssoForAccessCode).toBeDefined();
   });
 
   it("can make a call to exchange an NPSSO token for an access code", async () => {
@@ -32,7 +32,7 @@ describe("Function: exchangeNpssoForCode", () => {
     );
 
     // ACT
-    const code = await exchangeNpssoForCode("mockNpsso");
+    const code = await exchangeNpssoForAccessCode("mockNpsso");
 
     // ASSERT
     expect(code).toEqual(mockCode);
@@ -47,6 +47,6 @@ describe("Function: exchangeNpssoForCode", () => {
     );
 
     // ASSERT
-    await expect(exchangeNpssoForCode("mockNpsso")).rejects.toThrow();
+    await expect(exchangeNpssoForAccessCode("mockNpsso")).rejects.toThrow();
   });
 });

--- a/src/authenticate/exchangeNpssoForAccessCode.ts
+++ b/src/authenticate/exchangeNpssoForAccessCode.ts
@@ -8,12 +8,12 @@ import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
  * @returns An access code, which can be exchanged for an access token using `exchangeCodeForAccessToken`.
  * @example
  * ```ts
- * const code = await exchangeNpssoForCode("myNpssoToken");
+ * const code = await exchangeNpssoForAccessCode("myNpssoToken");
  *
  * console.log(code) // --> "v3.XXXXXX"
  * ```
  */
-export const exchangeNpssoForCode = async (
+export const exchangeNpssoForAccessCode = async (
   npssoToken: string
 ): Promise<string> => {
   const queryString = new URLSearchParams({
@@ -53,3 +53,8 @@ export const exchangeNpssoForCode = async (
 
   return redirectParams.get("code") as string;
 };
+
+/**
+ * @deprecated Use `exchangeNpssoForAccessCode` instead. This alias will be removed in a future version.
+ */
+export const exchangeNpssoForCode = exchangeNpssoForAccessCode;

--- a/src/authenticate/index.ts
+++ b/src/authenticate/index.ts
@@ -1,3 +1,3 @@
 export * from "./exchangeCodeForAccessToken";
-export * from "./exchangeNpssoForCode";
+export * from "./exchangeNpssoForAccessCode";
 export * from "./exchangeRefreshTokenForAuthTokens";

--- a/website/docs/api-docs/authentication.md
+++ b/website/docs/api-docs/authentication.md
@@ -43,16 +43,16 @@ An `AuthTokenResponse` object, containing the following properties:
 
 ---
 
-## exchangeNpssoForCode
+## exchangeNpssoForAccessCode
 
 This function lets you exchange your NPSSO token for an access code. If you do not have an NPSSO, see the guide on [authenticating manually](/authentication/authenticating-manually).
 
 ### Example
 
 ```ts
-import { exchangeNpssoForCode } from "psn-api";
+import { exchangeNpssoForAccessCode } from "psn-api";
 
-const accessCode = await exchangeNpssoForCode("<my 64-digit NPSSO>");
+const accessCode = await exchangeNpssoForAccessCode("<my 64-digit NPSSO>");
 
 console.log(accessCode); // --> "v3.ABCDEF"
 ```
@@ -71,7 +71,7 @@ An access code, which can be exchanged for access and refresh tokens with [excha
 
 ### Source
 
-[authenticate/exchangeNpssoForCode.ts](https://github.com/wescopeland/psn-api/blob/main/src/authenticate/exchangeNpssoForCode.ts)
+[authenticate/exchangeNpssoForAccessCode.ts](https://github.com/wescopeland/psn-api/blob/main/src/authenticate/exchangeNpssoForAccessCode.ts)
 
 ## exchangeRefreshTokenForAuthTokens
 
@@ -84,7 +84,7 @@ import { exchangeRefreshTokenForAuthTokens } from "psn-api";
 
 // Let's assume at some point in history
 // we've done the below initial log in.
-const accessCode = await exchangeNpssoForCode(npsso);
+const accessCode = await exchangeNpssoForAccessCode(npsso);
 const authorization = await exchangeCodeForAccessToken(accessCode);
 
 // Now, let's pretend `authorization.accessToken` has expired.

--- a/website/docs/authentication/authenticating-manually.md
+++ b/website/docs/authentication/authenticating-manually.md
@@ -45,7 +45,7 @@ You can now obtain an access token and a refresh token using your NPSSO with the
 const myNpsso = "<64 character token>";
 
 // We'll exchange your NPSSO for a special access code.
-const accessCode = await exchangeNpssoForCode(npsso);
+const accessCode = await exchangeNpssoForAccessCode(npsso);
 
 // 🚀 We can use the access code to get your access token and refresh token.
 const authorization = await exchangeCodeForAccessToken(accessCode);
@@ -53,5 +53,5 @@ const authorization = await exchangeCodeForAccessToken(accessCode);
 
 ## API
 
-- [exchangeNpssoForCode](/api-docs/authentication#exchangenpssoforcode)
+- [exchangeNpssoForAccessCode](/api-docs/authentication#exchangenpssoforaccesscode)
 - [exchangeCodeForAccessToken](/api-docs/authentication#exchangecodeforaccesstoken)

--- a/website/docs/examples/user-trophy-list.md
+++ b/website/docs/examples/user-trophy-list.md
@@ -18,7 +18,7 @@ import fs from "fs";
 import type { Trophy } from "psn-api";
 import {
   exchangeCodeForAccessToken,
-  exchangeNpssoForCode,
+  exchangeNpssoForAccessCode,
   getTitleTrophies,
   getUserTitles,
   getUserTrophiesEarnedForTitle,
@@ -29,7 +29,7 @@ import {
 async function main() {
   // 1. Authenticate and become authorized with PSN.
   // See the Authenticating Manually docs for how to get your NPSSO.
-  const accessCode = await exchangeNpssoForCode(process.env["NPSSO"]);
+  const accessCode = await exchangeNpssoForAccessCode(process.env["NPSSO"]);
   const authorization = await exchangeCodeForAccessToken(accessCode);
 
   // 2. Get the user's `accountId` from the username.

--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -33,7 +33,7 @@ If you see an error response, try using a different browser.
 const myNpsso = "<64 character token>";
 
 // We'll exchange your NPSSO for a special access code.
-const accessCode = await exchangeNpssoForCode(npsso);
+const accessCode = await exchangeNpssoForAccessCode(npsso);
 
 // 🚀 We can use the access code to get your access token and refresh token.
 const authorization = await exchangeCodeForAccessToken(accessCode);


### PR DESCRIPTION
Hello! This PR addresses the issue at https://github.com/achievements-app/psn-api/issues/30, which has been open for nearly three years. Thanks!

P.S.: I marked `exchangeNpssoForCode `function as deprecated. Let me know if you want me to remove the deprecation notice.