### PR TITLE
fix: alias exchangeCodeForAccessToken to exchangeAccessCodeForAuthTokens

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ const myNpsso = "<64 character token>";
 const accessCode = await exchangeNpssoForAccessCode(myNpsso);
 
 // We can use the access code to get your access token and refresh token.
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 ```
 
 4. You should now be all set to use any endpoint provided by this package. Each function requires as its first argument an object containing your access token. ex:
 
 ```ts
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 
 // This returns a list of all the games you've earned trophies for.
 const userTitlesResponse = await getUserTitles(
@@ -107,7 +107,7 @@ Click the function names to open their complete docs on the docs site.
 
 ### Authentication
 
-- [`exchangeCodeForAccessToken()`](https://psn-api.achievements.app/api-docs/authentication#exchangecodeforaccesstoken) - Exchange your access code for access and refresh tokens.
+- [`exchangeAccessCodeForAuthTokens()`](https://psn-api.achievements.app/api-docs/authentication#exchangeaccesscodeforauthtokens) - Exchange your access code for access and refresh tokens.
 - [`exchangeNpssoForAccessCode()`](https://psn-api.achievements.app/api-docs/authentication#exchangenpssoforaccesscode) - Exchange your NPSSO for an access code.
 - [`exchangeRefreshTokenForAuthTokens()`](https://psn-api.achievements.app/api-docs/authentication#exchangerefreshtokenforauthtokens) - Get a new access token using your refresh token (bypassing the need to constantly auth with your NPSSO).
 

--- a/src/__playground.ts
+++ b/src/__playground.ts
@@ -17,7 +17,7 @@
  * able to either.
  */
 import {
-  exchangeCodeForAccessToken,
+  exchangeAccessCodeForAuthTokens,
   exchangeNpssoForAccessCode,
   getUserTitles
 } from "./index";
@@ -37,7 +37,7 @@ async function main() {
   }
 
   const accessCode = await exchangeNpssoForAccessCode(myNpsso);
-  const authorization = await exchangeCodeForAccessToken(accessCode);
+  const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 
   const userTitlesResponse = await getUserTitles(
     { accessToken: authorization.accessToken },

--- a/src/authenticate/exchangeAccessCodeForAuthTokens.test.ts
+++ b/src/authenticate/exchangeAccessCodeForAuthTokens.test.ts
@@ -3,11 +3,11 @@ import { setupServer } from "msw/node";
 
 import type { AuthTokensResponse } from "../models";
 import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
-import { exchangeCodeForAccessToken } from "./exchangeCodeForAccessToken";
+import { exchangeAccessCodeForAuthTokens } from "./exchangeAccessCodeForAuthTokens";
 
 const server = setupServer();
 
-describe("Function: exchangeCodeForAccessToken", () => {
+describe("Function: exchangeAccessCodeForAuthTokens", () => {
   // MSW Setup
   beforeAll(() => server.listen());
   afterEach(() => server.resetHandlers());
@@ -15,7 +15,7 @@ describe("Function: exchangeCodeForAccessToken", () => {
 
   it("is defined #sanity", () => {
     // ASSERT
-    expect(exchangeCodeForAccessToken).toBeDefined();
+    expect(exchangeAccessCodeForAuthTokens).toBeDefined();
   });
 
   it("makes a call to exchange an access code for a set of OAuth tokens", async () => {
@@ -48,7 +48,7 @@ describe("Function: exchangeCodeForAccessToken", () => {
     );
 
     // ACT
-    const tokenResponse = await exchangeCodeForAccessToken("mockAccessCode");
+    const tokenResponse = await exchangeAccessCodeForAuthTokens("mockAccessCode");
 
     // ASSERT
     expect(tokenResponse).toEqual(mockAuthTokensResponse);

--- a/src/authenticate/exchangeAccessCodeForAuthTokens.ts
+++ b/src/authenticate/exchangeAccessCodeForAuthTokens.ts
@@ -7,7 +7,7 @@ import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
  * @param accessCode Your access code, typically retrieved by using `exchangeNpssoForAccessCode()`.
  * @returns An object containing an access token, refresh token, and expiry times for both.
  */
-export const exchangeCodeForAccessToken = async (
+export const exchangeAccessCodeForAuthTokens = async (
   accessCode: string
 ): Promise<AuthTokensResponse> => {
   const requestUrl = `${AUTH_BASE_URL}/token`;
@@ -39,3 +39,8 @@ export const exchangeCodeForAccessToken = async (
     tokenType: raw.token_type
   };
 };
+
+/**
+ * @deprecated Use `exchangeAccessCodeForAuthTokens` instead. This alias will be removed in a future version.
+ */
+export const exchangeCodeForAccessToken = exchangeAccessCodeForAuthTokens;

--- a/src/authenticate/exchangeNpssoForAccessCode.ts
+++ b/src/authenticate/exchangeNpssoForAccessCode.ts
@@ -5,7 +5,7 @@ import { AUTH_BASE_URL } from "./AUTH_BASE_URL";
 /**
  *
  * @param npssoToken Your NPSSO token, retrieved from https://ca.account.sony.com/api/v1/ssocookie
- * @returns An access code, which can be exchanged for an access token using `exchangeCodeForAccessToken`.
+ * @returns An access code, which can be exchanged for an access token using `exchangeAccessCodeForAuthTokens`.
  * @example
  * ```ts
  * const code = await exchangeNpssoForAccessCode("myNpssoToken");

--- a/src/authenticate/index.ts
+++ b/src/authenticate/index.ts
@@ -1,3 +1,3 @@
-export * from "./exchangeCodeForAccessToken";
+export * from "./exchangeAccessCodeForAuthTokens";
 export * from "./exchangeNpssoForAccessCode";
 export * from "./exchangeRefreshTokenForAuthTokens";

--- a/src/graphql/getRecentlyPlayedGames.ts
+++ b/src/graphql/getRecentlyPlayedGames.ts
@@ -18,7 +18,7 @@ type GetRecentlyPlayedGamesOptions = Pick<AllCallOptions, "limit"> & {
  *
  * This is useful if you want recent activity that isn't tied to trophy progress.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  */
 export const getRecentlyPlayedGames = async (
   authorization: AuthorizationPayload,

--- a/src/trophy/title/getTitleTrophies.ts
+++ b/src/trophy/title/getTitleTrophies.ts
@@ -23,7 +23,7 @@ type GetTitleTrophiesOptions = Pick<
  * When the title platform is PS3, PS4 or PS Vita you __must__ specify the
  * `npServiceName` parameter as `"trophy"`.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param npCommunicationId Unique ID of the title.
  * @param trophyGroupId `"all"` to return all trophies for the title, otherwise restrict results to a specific trophy group (such as a DLC).
  * @param options.npServiceName `"trophy"` for PS3, PS4, or PS Vita platforms. `"trophy2"` for the PS5 platform.

--- a/src/trophy/title/getTitleTrophyGroups.ts
+++ b/src/trophy/title/getTitleTrophyGroups.ts
@@ -22,7 +22,7 @@ type GetTitleTrophyGroupsOptions = Pick<
  * This also includes a summary of the number of trophies for the
  * title, broken down by group and grade (gold, silver, etc.).
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param npCommunicationId The unique ID of the game title you wish to retrieve the trophy groups list for.
  * @param options.npServiceName `"trophy"` for PS3, PS4, or PS Vita platforms. `"trophy2"` for the PS5 platform.
  * @param options.headerOverrides Override the headers in the request to the PSN API, such as to change the language.

--- a/src/trophy/user/getUserTitles.ts
+++ b/src/trophy/user/getUserTitles.ts
@@ -38,7 +38,7 @@ type GetUserTitlesOptions = Pick<
  * so the first result will be the title for which a trophy was most recently earned
  * (or synced for the first time in the case of a game with 0% progress).
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  * @param options.limit Limit the number of titles returned.
  * @param options.offset Return title data from this result onwards.

--- a/src/trophy/user/getUserTrophiesEarnedForTitle.ts
+++ b/src/trophy/user/getUserTrophiesEarnedForTitle.ts
@@ -38,7 +38,7 @@ type GetUserTrophiesEarnedForTitleOptions = Pick<
  * with their account (ie. the title has not been launched and allowed to
  * sync at least once) then a Resource Not Found error will be thrown.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  * @param npCommunicationId Unique ID of the title.
  * @param trophyGroupId `"all"` to return all trophies for the title, otherwise restrict results to a specific trophy group (such as a DLC).

--- a/src/trophy/user/getUserTrophyGroupEarningsForTitle.ts
+++ b/src/trophy/user/getUserTrophyGroupEarningsForTitle.ts
@@ -49,7 +49,7 @@ interface GetUserTrophyGroupEarningsForTitleOptions {
  * with their account (ie. the title has not been launched and allowed to
  * sync at least once) then a Resource Not Found error will be thrown.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  * @param npCommunicationId Unique ID of the title.
  * @param options.npServiceName `"trophy"` for PS3, PS4, or PS Vita platforms. `"trophy2"` for the PS5 platform.

--- a/src/trophy/user/getUserTrophyProfileSummary.ts
+++ b/src/trophy/user/getUserTrophyProfileSummary.ts
@@ -25,7 +25,7 @@ type GetUserTrophyProfileSummaryOptions = Pick<
  *
  * To find a user's `accountId`, the `makeUniversalSearch()` function can be used.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  * @param options.headerOverrides Override the headers in the request to the PSN API, such as to change the language.
  */

--- a/src/user/getBasicPresence.ts
+++ b/src/user/getBasicPresence.ts
@@ -14,7 +14,7 @@ type GetBasicPresenceOptions = Pick<AllCallOptions, "headerOverrides">;
  * If the account's profile cannot be found (either due to non-existence or privacy settings),
  * an error will be thrown.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The accountId for the user you wish to retrieve a profile for.
  * @param options Optional - Additional headerOverride options to provide for the request
  */

--- a/src/user/getProfileFromAccountId.ts
+++ b/src/user/getProfileFromAccountId.ts
@@ -14,7 +14,7 @@ type GetProfileFromAccountIdOptions = Pick<AllCallOptions, "headerOverrides">;
  * If the account's profile cannot be found (either due to non-existence or privacy settings),
  * an error will be thrown.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The accountId for the user you wish to retrieve a profile for.
  */
 export const getProfileFromAccountId = async (

--- a/src/user/getProfileFromUserName.ts
+++ b/src/user/getProfileFromUserName.ts
@@ -14,7 +14,7 @@ import { call } from "../utils/call";
  * is recommended instead. This endpoint is here because it can return interesting
  * presence information when the user is playing on a legacy console such as a PS3.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param userName The username for the user you wish to retrieve a profile for.
  */
 export const getProfileFromUserName = async (

--- a/src/user/getUserFriendsAccountIds.ts
+++ b/src/user/getUserFriendsAccountIds.ts
@@ -16,7 +16,7 @@ type GetUserFriendsAccountIdsOptions = Pick<AllCallOptions, "limit" | "offset">;
  *
  *  To find a user's `accountId`, the `makeUniversalSearch()` function can be used.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  */
 export const getUserFriendsAccountIds = async (

--- a/src/user/getUserPlayedGames.ts
+++ b/src/user/getUserPlayedGames.ts
@@ -17,7 +17,7 @@ interface GetUserGamesOptions extends Pick<AllCallOptions, "limit" | "offset"> {
  * The list is sorted by recently played by default.
  * If the list cannot be found (either due to non-existence or privacy settings), an error will be thrown.
  *
- * @param authorization An object containing your access token, typically retrieved with `exchangeCodeForAccessToken()`.
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account id to be queried. Use `"me"` for the authenticating account.
  */
 export async function getUserPlayedGames(

--- a/website/docs/api-docs/authentication.md
+++ b/website/docs/api-docs/authentication.md
@@ -5,16 +5,16 @@ sidebar_position: 1
 
 # Authentication API
 
-## exchangeCodeForAccessToken
+## exchangeAccessCodeForAuthTokens
 
 This function lets you exchange your access code for access and refresh tokens. If you do not have an access code, see the guide on [authenticating manually](/authentication/authenticating-manually).
 
 ### Example
 
 ```ts
-import { exchangeCodeForAccessToken } from "psn-api";
+import { exchangeAccessCodeForAuthTokens } from "psn-api";
 
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 ```
 
 ### Parameters
@@ -39,7 +39,7 @@ An `AuthTokenResponse` object, containing the following properties:
 
 ### Source
 
-[authenticate/exchangeCodeForAccessToken.ts](https://github.com/achievements-app/psn-api/blob/main/src/authenticate/exchangeCodeForAccessToken.ts)
+[authenticate/exchangeAccessCodeForAuthTokens.ts](https://github.com/achievements-app/psn-api/blob/main/src/authenticate/exchangeAccessCodeForAuthTokens.ts)
 
 ---
 
@@ -67,7 +67,7 @@ console.log(accessCode); // --> "v3.ABCDEF"
 
 `Promise<string>`
 
-An access code, which can be exchanged for access and refresh tokens with [exchangeCodeForAccessToken()](/api-docs/authentication#exchangecodeforaccesstoken).
+An access code, which can be exchanged for access and refresh tokens with [exchangeAccessCodeForAuthTokens()](/api-docs/authentication#exchangeaccesscodeforauthtokens).
 
 ### Source
 
@@ -85,7 +85,7 @@ import { exchangeRefreshTokenForAuthTokens } from "psn-api";
 // Let's assume at some point in history
 // we've done the below initial log in.
 const accessCode = await exchangeNpssoForAccessCode(npsso);
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 
 // Now, let's pretend `authorization.accessToken` has expired.
 // Rather than using the above process (via NPSSO) to get a new one,

--- a/website/docs/authentication/authenticating-manually.md
+++ b/website/docs/authentication/authenticating-manually.md
@@ -48,10 +48,10 @@ const myNpsso = "<64 character token>";
 const accessCode = await exchangeNpssoForAccessCode(npsso);
 
 // 🚀 We can use the access code to get your access token and refresh token.
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 ```
 
 ## API
 
 - [exchangeNpssoForAccessCode](/api-docs/authentication#exchangenpssoforaccesscode)
-- [exchangeCodeForAccessToken](/api-docs/authentication#exchangecodeforaccesstoken)
+- [exchangeAccessCodeForAuthTokens](/api-docs/authentication#exchangeaccesscodeforauthtokens)

--- a/website/docs/authentication/using-your-refresh-token.md
+++ b/website/docs/authentication/using-your-refresh-token.md
@@ -6,7 +6,7 @@ For security reasons, access tokens are short-lived and expire relatively quickl
 
 ## The refresh token usage flow
 
-1. Before using a psn-api function, you check `expiresIn` (returned from [`exchangeCodeForAccessToken()`](/api-docs/authentication#exchangecodeforaccesstoken)) to see if your current `accessToken` is expired.
+1. Before using a psn-api function, you check `expiresIn` (returned from [`exchangeAccessCodeForAuthTokens()`](/api-docs/authentication#exchangeaccesscodeforauthtokens)) to see if your current `accessToken` is expired.
 
 2. If it's expired, you use [`exchangeRefreshTokenForAuthTokens()`](/api-docs/authentication#exchangerefreshtokenforauthtokens) to get a new access token.
 
@@ -21,7 +21,7 @@ psn-api is unopinionated about how you store access and refresh tokens &mdash; _
 ```ts
 // We're going to be working with the authorization object
 // returned from this function we used when we first authenticated.
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 
 // We'll take the `expiresIn` value and convert it to an
 // ISO date string (eg- "2021-11-02T01:02:03.246Z").
@@ -41,7 +41,7 @@ const isAccessTokenExpired = new Date(expirationDate).getTime() < now.getTime();
 if (isAccessTokenExpired) {
   // We'll use our refresh token to get a new access token.
   // Assuming success, this function returns an auth object
-  // with the same shape as the response from `exchangeCodeForAccessToken()`.
+  // with the same shape as the response from `exchangeAccessCodeForAuthTokens()`.
   const updatedAuthorization = await exchangeRefreshTokenForAuthTokens(
     authorization.refreshToken
   );

--- a/website/docs/examples/user-trophy-list.md
+++ b/website/docs/examples/user-trophy-list.md
@@ -17,7 +17,7 @@ import fs from "fs";
 
 import type { Trophy } from "psn-api";
 import {
-  exchangeCodeForAccessToken,
+  exchangeAccessCodeForAuthTokens,
   exchangeNpssoForAccessCode,
   getTitleTrophies,
   getUserTitles,
@@ -30,7 +30,7 @@ async function main() {
   // 1. Authenticate and become authorized with PSN.
   // See the Authenticating Manually docs for how to get your NPSSO.
   const accessCode = await exchangeNpssoForAccessCode(process.env["NPSSO"]);
-  const authorization = await exchangeCodeForAccessToken(accessCode);
+  const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 
   // 2. Get the user's `accountId` from the username.
   const allAccountsSearchResults = await makeUniversalSearch(

--- a/website/docs/get-started.md
+++ b/website/docs/get-started.md
@@ -36,7 +36,7 @@ const myNpsso = "<64 character token>";
 const accessCode = await exchangeNpssoForAccessCode(npsso);
 
 // 🚀 We can use the access code to get your access token and refresh token.
-const authorization = await exchangeCodeForAccessToken(accessCode);
+const authorization = await exchangeAccessCodeForAuthTokens(accessCode);
 ```
 
 4. You now have all you need to use any function in the API. Each function takes this authorization object as its first argument. **To be more precise, the functions are looking for your `accessToken` value.** Here's an example:


### PR DESCRIPTION
Hello again! This PR also addresses the issue at https://github.com/achievements-app/psn-api/issues/29. Thanks again, and thanks for the quick merge!