### PR TITLE
feat(user): add getProfileShareableLink function to share a user profile publicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Click the function names to open their complete docs on the docs site.
 - [`getBasicPresence()`](https://psn-api.achievements.app/api-docs/users#getbasicpresence) - Get a user's basic presence
   information.
 - [`getUserRegion()`](https://psn-api.achievements.app/api-docs/users#getuserregion) - Get a user's region information based on their username.
+- [`getProfileShareableLink()`](https://psn-api.achievements.app/api-docs/users#getprofileshareablelink) - Get a shareable link and QR code for a user's profile.
 
 ### Trophies
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -8,6 +8,7 @@ export * from "./profile-from-account-id-response.model";
 export * from "./profile-from-user-name-response.model";
 export * from "./rarest-thin-trophy.model";
 export * from "./recently-played-games-response.model";
+export * from "./shareable-profile-link-response.model";
 export * from "./social-account-result.model";
 export * from "./title-platform.model";
 export * from "./title-thin-trophy.model";

--- a/src/models/shareable-profile-link-response.model.ts
+++ b/src/models/shareable-profile-link-response.model.ts
@@ -1,0 +1,19 @@
+export interface ShareableProfileLinkResponse {
+  /**
+   * The shareable URL for the user's PlayStation profile.
+   * This link can be shared with others to view the user's public profile.
+   */
+  shareUrl: string;
+
+  /**
+   * The URL to a shareable image representing the user's profile.
+   * This image can be shared on social media or other platforms.
+   */
+  shareImageUrl: string;
+
+  /**
+   * The destination URL that the shareable image links to.
+   * This is typically the user's profile page when accessed via the shared image.
+   */
+  shareImageUrlDestination: string;
+}

--- a/src/user/USER_BASE_URL.ts
+++ b/src/user/USER_BASE_URL.ts
@@ -6,3 +6,6 @@ export const USER_GAMES_BASE_URL =
 
 export const USER_LEGACY_BASE_URL =
   "https://us-prof.np.community.playstation.net/userProfile/v1/users";
+
+export const USER_CPSS_BASE_URL = 
+  "https://m.np.playstation.com/api/cpss";

--- a/src/user/getProfileShareableLink.test.ts
+++ b/src/user/getProfileShareableLink.test.ts
@@ -63,7 +63,7 @@ describe("Function: getProfileShareableLink", () => {
     const mockResponse = {
       error: {
         referenceId: "d71bd8ff-5f63-11ec-87da-d5dfd3bc6e67",
-        code: 2105356,
+        code: 2_105_356,
         message: "User not found"
       }
     };

--- a/src/user/getProfileShareableLink.test.ts
+++ b/src/user/getProfileShareableLink.test.ts
@@ -1,0 +1,115 @@
+import nock from "nock";
+
+import type {
+  AuthorizationPayload,
+  ShareableProfileLinkResponse
+} from "../models";
+import { getProfileShareableLink } from "./getProfileShareableLink";
+import { USER_CPSS_BASE_URL } from "./USER_BASE_URL";
+
+describe("Function: getProfileShareableLink", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("is defined #sanity", () => {
+    // ASSERT
+    expect(getProfileShareableLink).toBeDefined();
+  });
+
+  it("retrieves a shareable profile link for a given account ID", async () => {
+    // ARRANGE
+    const mockAuthorization: AuthorizationPayload = {
+      accessToken: "mockAccessToken"
+    };
+
+    const mockAccountId = "2984038888603282554";
+
+    const mockResponse: ShareableProfileLinkResponse = {
+      shareUrl: "https://www.playstation.com/acct/profile/2984038888603282554",
+      shareImageUrl:
+        "https://image.api.playstation.com/vulcan/ap/rnd/202211/0711/mockProfileShareImage.png",
+      shareImageUrlDestination:
+        "https://www.playstation.com/acct/profile/2984038888603282554"
+    };
+
+    const baseUrlObj = new URL(USER_CPSS_BASE_URL);
+    const baseUrl = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
+    const basePath = baseUrlObj.pathname;
+
+    nock(baseUrl)
+      .get(`${basePath}/v1/share/profile/${mockAccountId}`)
+      .query(true)
+      .reply(200, mockResponse);
+
+    // ACT
+    const response = await getProfileShareableLink(
+      mockAuthorization,
+      mockAccountId
+    );
+
+    // ASSERT
+    expect(response).toEqual(mockResponse);
+  });
+
+  it("throws an error if we receive a response containing an `error` object", async () => {
+    // ARRANGE
+    const mockAuthorization: AuthorizationPayload = {
+      accessToken: "mockAccessToken"
+    };
+
+    const mockAccountId = "invalidAccountId123";
+
+    const mockResponse = {
+      error: {
+        referenceId: "d71bd8ff-5f63-11ec-87da-d5dfd3bc6e67",
+        code: 2105356,
+        message: "User not found"
+      }
+    };
+
+    const baseUrlObj = new URL(USER_CPSS_BASE_URL);
+    const baseUrl = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
+    const basePath = baseUrlObj.pathname;
+
+    nock(baseUrl)
+      .get(`${basePath}/v1/share/profile/${mockAccountId}`)
+      .query(true)
+      .reply(200, mockResponse);
+
+    // ASSERT
+    await expect(
+      getProfileShareableLink(mockAuthorization, mockAccountId)
+    ).rejects.toThrow("User not found");
+  });
+
+  it("throws an error with default message if error object has no message", async () => {
+    // ARRANGE
+    const mockAuthorization: AuthorizationPayload = {
+      accessToken: "mockAccessToken"
+    };
+
+    const mockAccountId = "someAccountId";
+
+    const mockResponse = {
+      error: {
+        referenceId: "d71bd8ff-5f63-11ec-87da-d5dfd3bc6e67",
+        code: 500
+      }
+    };
+
+    const baseUrlObj = new URL(USER_CPSS_BASE_URL);
+    const baseUrl = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
+    const basePath = baseUrlObj.pathname;
+
+    nock(baseUrl)
+      .get(`${basePath}/v1/share/profile/${mockAccountId}`)
+      .query(true)
+      .reply(200, mockResponse);
+
+    // ASSERT
+    await expect(
+      getProfileShareableLink(mockAuthorization, mockAccountId)
+    ).rejects.toThrow("Unexpected Error");
+  });
+});

--- a/src/user/getProfileShareableLink.ts
+++ b/src/user/getProfileShareableLink.ts
@@ -1,0 +1,38 @@
+import type {
+  AuthorizationPayload,
+  ShareableProfileLinkResponse
+} from "../models";
+import { buildRequestUrl } from "../utils/buildRequestUrl";
+import { call } from "../utils/call";
+import { USER_CPSS_BASE_URL } from "./USER_BASE_URL"
+
+/**
+ * A call to this function will retrieve a shareable link and QR code for a PlayStation Network user's profile.
+ * The shareable link allows others to view the user's public profile information, and the QR code provides
+ * a convenient way to share the profile via scanning.
+ *
+ * If the user's profile cannot be found or accessed,
+ * an error will be thrown.
+ *
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
+ * @param accountId The account ID for the user whose shareable profile link you want to retrieve.
+ */
+export const getProfileShareableLink = async (
+  authorization: AuthorizationPayload,
+  accountId: string
+): Promise<ShareableProfileLinkResponse> => {
+  const url = buildRequestUrl(USER_CPSS_BASE_URL, "/v1/share/profile/:accountId", {}, {
+    accountId
+  });
+
+  const response = await call<ShareableProfileLinkResponse>(
+    { url },
+    authorization
+  );
+
+  if ((response as any)?.error) {
+    throw new Error((response as any)?.error?.message ?? "Unexpected Error");
+  }
+
+  return response;
+};

--- a/src/user/index.ts
+++ b/src/user/index.ts
@@ -1,6 +1,7 @@
 export * from "./getBasicPresence";
 export * from "./getProfileFromAccountId";
 export * from "./getProfileFromUserName";
+export * from "./getProfileShareableLink";
 export * from "./getUserFriendsAccountIds";
 export * from "./getUserPlayedGames";
 export * from "./getUserRegion";

--- a/website/docs/api-docs/users.md
+++ b/website/docs/api-docs/users.md
@@ -106,6 +106,49 @@ The following properties are contained within a `profile` object that is returne
 
 ---
 
+## getProfileShareableLink
+
+A call to this function will retrieve a shareable link and QR code for a PlayStation Network user's profile. The shareable link allows others to view the user's public profile information, and the QR code provides a convenient way to share the profile via scanning.
+
+If the user's profile cannot be found or accessed, an error will be thrown.
+
+### Examples
+
+#### Get a shareable link for a user's profile
+
+```ts
+import { getProfileShareableLink } from "psn-api";
+
+const shareableLink = await getProfileShareableLink(
+  authorization,
+  "962157895908076652"
+);
+
+console.log(shareableLink.shareUrl); // Direct link to the profile
+console.log(shareableLink.shareImageUrl); // QR code image URL
+```
+
+### Returns
+
+| Name                       | Type     | Description                                                                                     |
+| :------------------------- | :------- | :---------------------------------------------------------------------------------------------- |
+| `shareUrl`                 | `string` | The shareable URL for the user's PlayStation profile that can be shared with others.           |
+| `shareImageUrl`            | `string` | The URL to a shareable image (QR code) representing the user's profile for social media sharing. |
+| `shareImageUrlDestination` | `string` | The destination URL that the shareable image links to when accessed via the shared image.      |
+
+### Parameters
+
+| Name            | Type                                                                  | Description                                                                                                                                                                                                                 |
+| :-------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one.                                                                                                  |
+| `accountId`     | `string`                                                              | The account whose shareable profile link is being retrieved. Use `"me"` for the authenticating account. To find a user's `accountId`, the [`makeUniversalSearch()`](/api-docs/universal-search#makeuniversalsearch) function can be used. |
+
+### Source
+
+[user/getProfileShareableLink.ts](https://github.com/achievements-app/psn-api/blob/main/src/user/getProfileShareableLink.ts)
+
+---
+
 ## getUserFriendsAccountIds
 
 A call to this function will retrieve the list of friended `accountId` values associated with the given `accountId` parameter. If the friends list cannot be retrieved (either due to the given `accountId` not existing or due to the user's privacy settings), an error will be thrown.


### PR DESCRIPTION
This PR resolves https://github.com/achievements-app/psn-api/issues/200.