### PR TITLE
feat: add getUserTrophiesForSpecificTitle function

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Click the function names to open their complete docs on the docs site.
 - [`getUserTrophiesEarnedForTitle()`](https://psn-api.achievements.app/api-docs/user-trophies#getusertrophiesearnedfortitle) - Retrieve the earned status of trophies for a user from either a single or all trophy groups in a title.
 - [`getUserTrophyGroupEarningsForTitle()`](https://psn-api.achievements.app/api-docs/user-trophies#getusertrophygroupearningsfortitle) - Get a summary of trophies earned for a user broken down by trophy group within a title.
 - [`getUserTrophyProfileSummary()`](https://psn-api.achievements.app/api-docs/user-trophies#getusertrophyprofilesummary) - Retrieve an overall summary of the number of trophies earned for a user broken down by type.
+- [`getUserTrophiesForSpecificTitle()`](https://psn-api.achievements.app/api-docs/user-trophies#getUserTrophiesForSpecificTitle) - Retrieve a summary of the trophies earned by a user for specific titles.
 - [`getRecentlyPlayedGames()`](https://psn-api.achievements.app/api-docs/users#getrecentlyplayedgames) - Retrieve a list of recently played games for the user associated with the access token provided to this function.
 - [`getUserPlayedGames()`](https://psn-api.achievements.app/api-docs/users#getuserplayedgames) - Retrieve a list of played games and playtime info (ordered by recency) associated with a user (either from token or external if privacy settings allow).
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,5 +28,6 @@ export * from "./user-region-info.model";
 export * from "./user-thin-trophy.model";
 export * from "./user-titles-response.model";
 export * from "./user-trophies-earned-for-title-response.model";
+export * from './user-trophies-for-specific-title-response.model';
 export * from "./user-trophy-group-earnings-for-title-response.model";
 export * from "./user-trophy-profile-summary-response.model";

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -28,6 +28,6 @@ export * from "./user-region-info.model";
 export * from "./user-thin-trophy.model";
 export * from "./user-titles-response.model";
 export * from "./user-trophies-earned-for-title-response.model";
-export * from './user-trophies-for-specific-title-response.model';
+export * from "./user-trophies-for-specific-title-response.model";
 export * from "./user-trophy-group-earnings-for-title-response.model";
 export * from "./user-trophy-profile-summary-response.model";

--- a/src/models/user-trophies-for-specific-title-response.model.ts
+++ b/src/models/user-trophies-for-specific-title-response.model.ts
@@ -1,4 +1,4 @@
-import { TrophyTitle } from './trophy-title.model';
+import { TrophyTitle } from "./trophy-title.model";
 
 export interface UserTrophiesBySpecificTitleResponse {
   /** Individual object for each title returned */
@@ -9,6 +9,6 @@ export interface UserTrophiesBySpecificTitleResponse {
      * Trophy set associated with the title
      * This will only be returned if the queried account has played the title (and allowed their trophies to sync) at least once
      */
-    trophyTitles: TrophyTitle[]
-  }[]
+    trophyTitles: TrophyTitle[];
+  }[];
 }

--- a/src/models/user-trophies-for-specific-title-response.model.ts
+++ b/src/models/user-trophies-for-specific-title-response.model.ts
@@ -1,0 +1,14 @@
+import { TrophyTitle } from './trophy-title.model';
+
+export interface UserTrophiesBySpecificTitleResponse {
+  /** Individual object for each title returned */
+  titles: {
+    /** npTitleId of the title */
+    npTitleId: string;
+    /**
+     * Trophy set associated with the title
+     * This will only be returned if the queried account has played the title (and allowed their trophies to sync) at least once
+     */
+    trophyTitles: TrophyTitle[]
+  }[]
+}

--- a/src/trophy/user/getUserTrophiesForSpecificTitle.test.ts
+++ b/src/trophy/user/getUserTrophiesForSpecificTitle.test.ts
@@ -1,6 +1,9 @@
 import nock from "nock";
 
-import type { AuthorizationPayload, UserTrophiesBySpecificTitleResponse } from "../../models";
+import type {
+  AuthorizationPayload,
+  UserTrophiesBySpecificTitleResponse
+} from "../../models";
 import { generateTrophyTitle } from "../../test/generators";
 import { TROPHY_BASE_URL } from "../TROPHY_BASE_URL";
 import { getUserTrophiesForSpecificTitle } from "./getUserTrophiesForSpecificTitle";
@@ -23,21 +26,21 @@ describe("Function: getUserTrophiesForSpecificTitle", () => {
       accessToken: "mockAccessToken"
     };
     const mockOptions = {
-      npTitleIds: 'PPSA13195_00,PPSA27366_00',
+      npTitleIds: "PPSA13195_00,PPSA27366_00",
       includeNotEarnedTrophyIds: true
-    }
+    };
 
     const mockResponse: UserTrophiesBySpecificTitleResponse = {
       titles: [
         {
-          npTitleId: 'PPSA13195_00',
+          npTitleId: "PPSA13195_00",
           trophyTitles: [generateTrophyTitle()]
         },
         {
-          npTitleId: 'PPSA27366_00',
+          npTitleId: "PPSA27366_00",
           trophyTitles: [generateTrophyTitle()]
         }
-      ],
+      ]
     };
 
     const baseUrlObj = new URL(TROPHY_BASE_URL);
@@ -50,7 +53,11 @@ describe("Function: getUserTrophiesForSpecificTitle", () => {
       .reply(200, mockResponse);
 
     // ACT
-    const response = await getUserTrophiesForSpecificTitle(mockAuthorization, mockAccountId, mockOptions);
+    const response = await getUserTrophiesForSpecificTitle(
+      mockAuthorization,
+      mockAccountId,
+      mockOptions
+    );
 
     // ASSERT
     expect(response).toEqual(mockResponse);

--- a/src/trophy/user/getUserTrophiesForSpecificTitle.test.ts
+++ b/src/trophy/user/getUserTrophiesForSpecificTitle.test.ts
@@ -1,0 +1,58 @@
+import nock from "nock";
+
+import type { AuthorizationPayload, UserTrophiesBySpecificTitleResponse } from "../../models";
+import { generateTrophyTitle } from "../../test/generators";
+import { TROPHY_BASE_URL } from "../TROPHY_BASE_URL";
+import { getUserTrophiesForSpecificTitle } from "./getUserTrophiesForSpecificTitle";
+
+describe("Function: getUserTrophiesForSpecificTitle", () => {
+  afterEach(() => {
+    nock.cleanAll();
+  });
+
+  it("is defined #sanity", () => {
+    // ASSERT
+    expect(getUserTrophiesForSpecificTitle).toBeDefined();
+  });
+
+  it("makes a call to get the summary of the trophies earned by a user for specific titles", async () => {
+    // ARRANGE
+    const mockAccountId = "mockAccountId";
+
+    const mockAuthorization: AuthorizationPayload = {
+      accessToken: "mockAccessToken"
+    };
+    const mockOptions = {
+      npTitleIds: 'PPSA13195_00,PPSA27366_00',
+      includeNotEarnedTrophyIds: true
+    }
+
+    const mockResponse: UserTrophiesBySpecificTitleResponse = {
+      titles: [
+        {
+          npTitleId: 'PPSA13195_00',
+          trophyTitles: [generateTrophyTitle()]
+        },
+        {
+          npTitleId: 'PPSA27366_00',
+          trophyTitles: [generateTrophyTitle()]
+        }
+      ],
+    };
+
+    const baseUrlObj = new URL(TROPHY_BASE_URL);
+    const baseUrl = `${baseUrlObj.protocol}//${baseUrlObj.host}`;
+    const basePath = baseUrlObj.pathname;
+
+    nock(baseUrl)
+      .get(`${basePath}/v1/users/${mockAccountId}/titles/trophyTitles`)
+      .query(true)
+      .reply(200, mockResponse);
+
+    // ACT
+    const response = await getUserTrophiesForSpecificTitle(mockAuthorization, mockAccountId, mockOptions);
+
+    // ASSERT
+    expect(response).toEqual(mockResponse);
+  });
+});

--- a/src/trophy/user/getUserTrophiesForSpecificTitle.ts
+++ b/src/trophy/user/getUserTrophiesForSpecificTitle.ts
@@ -1,0 +1,54 @@
+
+import type {
+  AuthorizationPayload,
+  CallValidHeaders,
+  UserTrophiesBySpecificTitleResponse
+} from "../../models";
+import { buildRequestUrl } from "../../utils/buildRequestUrl";
+import { call } from "../../utils/call";
+import { TROPHY_BASE_URL } from "../TROPHY_BASE_URL";
+
+interface GetUserTrophiesForSpecificTitleOptions {
+  npTitleIds: string;
+  includeNotEarnedTrophyIds?: boolean;
+  headerOverrides?: CallValidHeaders;
+}
+
+/**
+ * A call to this function will retrieve a summary of the trophies earned by
+ * a user for specific titles.
+ * 
+ * This function can be used as a way of linking the npCommunicationId of
+ * a Trophy Set to a titles npTitleId,but as with the other user based endpoints
+ * in this version of the API you will only get a useful response back if the account
+ * you are querying against has played the title.
+ * 
+ * If you attempt to query a title ID which does not exist then a Resource not found error will be returned.
+ * 
+ * There is a limit of 5 title IDs which can be included in the npTitleIds query.
+ * Trying to include more than 5 will result in a Bad Request (query: npTitleId) error being returned.
+ * 
+ * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
+ * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
+ * @param options.npTitleIds The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). Every title has an ID assigned to it with these typically starting "CUSA" for PS4 titles and "PPSA" for PS5 titles.
+ * @param options.includeNotEarnedTrophyIds If optional parameter includeNotEarnedTrophyIds is included and set to true then the response will contain a list of IDs for the individual trophies which the user has not earned for each title ID queried. This functionality was added to the endpoint post release, most likely early 2023.
+ * @param options.headerOverrides Override the headers in the request to the PSN API, such as to change the language.
+ */
+export const getUserTrophiesForSpecificTitle = async (
+  authorization: AuthorizationPayload,
+  accountId: string,
+  options: GetUserTrophiesForSpecificTitleOptions
+): Promise<UserTrophiesBySpecificTitleResponse> => {
+  const { headerOverrides, ...args } = options;
+  const url = buildRequestUrl(
+    TROPHY_BASE_URL,
+    "/v1/users/:accountId/titles/trophyTitles",
+    {},
+    { accountId, ...args }
+  );
+
+  return await call<UserTrophiesBySpecificTitleResponse>(
+    { url, headers: headerOverrides },
+    authorization
+  );
+}

--- a/src/trophy/user/getUserTrophiesForSpecificTitle.ts
+++ b/src/trophy/user/getUserTrophiesForSpecificTitle.ts
@@ -1,4 +1,3 @@
-
 import type {
   AuthorizationPayload,
   CallValidHeaders,
@@ -17,17 +16,17 @@ interface GetUserTrophiesForSpecificTitleOptions {
 /**
  * A call to this function will retrieve a summary of the trophies earned by
  * a user for specific titles.
- * 
+ *
  * This function can be used as a way of linking the npCommunicationId of
  * a Trophy Set to a titles npTitleId,but as with the other user based endpoints
  * in this version of the API you will only get a useful response back if the account
  * you are querying against has played the title.
- * 
+ *
  * If you attempt to query a title ID which does not exist then a Resource not found error will be returned.
- * 
+ *
  * There is a limit of 5 title IDs which can be included in the npTitleIds query.
  * Trying to include more than 5 will result in a Bad Request (query: npTitleId) error being returned.
- * 
+ *
  * @param authorization An object containing your access token, typically retrieved with `exchangeAccessCodeForAuthTokens()`.
  * @param accountId The account whose trophy list is being accessed. Use `"me"` for the authenticating account.
  * @param options.npTitleIds The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). Every title has an ID assigned to it with these typically starting "CUSA" for PS4 titles and "PPSA" for PS5 titles.
@@ -51,4 +50,4 @@ export const getUserTrophiesForSpecificTitle = async (
     { url, headers: headerOverrides },
     authorization
   );
-}
+};

--- a/src/trophy/user/index.ts
+++ b/src/trophy/user/index.ts
@@ -1,4 +1,5 @@
 export * from "./getUserTitles";
 export * from "./getUserTrophiesEarnedForTitle";
+export * from './getUserTrophiesForSpecificTitle';
 export * from "./getUserTrophyGroupEarningsForTitle";
 export * from "./getUserTrophyProfileSummary";

--- a/src/trophy/user/index.ts
+++ b/src/trophy/user/index.ts
@@ -1,5 +1,5 @@
 export * from "./getUserTitles";
 export * from "./getUserTrophiesEarnedForTitle";
-export * from './getUserTrophiesForSpecificTitle';
+export * from "./getUserTrophiesForSpecificTitle";
 export * from "./getUserTrophyGroupEarningsForTitle";
 export * from "./getUserTrophyProfileSummary";

--- a/src/user/USER_BASE_URL.ts
+++ b/src/user/USER_BASE_URL.ts
@@ -7,5 +7,4 @@ export const USER_GAMES_BASE_URL =
 export const USER_LEGACY_BASE_URL =
   "https://us-prof.np.community.playstation.net/userProfile/v1/users";
 
-export const USER_CPSS_BASE_URL = 
-  "https://m.np.playstation.com/api/cpss";
+export const USER_CPSS_BASE_URL = "https://m.np.playstation.com/api/cpss";

--- a/src/user/getProfileShareableLink.ts
+++ b/src/user/getProfileShareableLink.ts
@@ -4,7 +4,7 @@ import type {
 } from "../models";
 import { buildRequestUrl } from "../utils/buildRequestUrl";
 import { call } from "../utils/call";
-import { USER_CPSS_BASE_URL } from "./USER_BASE_URL"
+import { USER_CPSS_BASE_URL } from "./USER_BASE_URL";
 
 /**
  * A call to this function will retrieve a shareable link and QR code for a PlayStation Network user's profile.
@@ -21,9 +21,14 @@ export const getProfileShareableLink = async (
   authorization: AuthorizationPayload,
   accountId: string
 ): Promise<ShareableProfileLinkResponse> => {
-  const url = buildRequestUrl(USER_CPSS_BASE_URL, "/v1/share/profile/:accountId", {}, {
-    accountId
-  });
+  const url = buildRequestUrl(
+    USER_CPSS_BASE_URL,
+    "/v1/share/profile/:accountId",
+    {},
+    {
+      accountId
+    }
+  );
 
   const response = await call<ShareableProfileLinkResponse>(
     { url },

--- a/src/utils/buildRequestUrl.ts
+++ b/src/utils/buildRequestUrl.ts
@@ -4,7 +4,7 @@ export const buildRequestUrl = (
   baseUrl: string,
   endpointUrl: string,
   options: Partial<AllCallOptions> = {},
-  args: Record<string, string | number> = {}
+  args: Record<string, string | number | boolean> = {}
 ) => {
   // eslint-disable-next-line @typescript-eslint/no-unused-vars -- This is an intentional pick.
   const { headerOverrides, ...pickedOptions } = options;

--- a/website/docs/api-docs/user-trophies.md
+++ b/website/docs/api-docs/user-trophies.md
@@ -278,32 +278,32 @@ This endpoint can be used as a way of linking the npCommunicationId of a Trophy 
 import { getUserTrophiesForSpecificTitle } from "psn-api";
 
 const response = await getUserTrophiesForSpecificTitle(authorization, "me", {
-  npTitleIds: 'PPSA13195_00,PPSA27366_00',
+  npTitleIds: "PPSA13195_00,PPSA27366_00",
   includeNotEarnedTrophyIds: true
 });
 ```
 
 ### Returns
 
-| Name             | Type                                                  | Description                                                     |
-| :--------------- | :---------------------------------------------------- | :-------------------------------------------------------------- |
-| `titles`   | `{ npTitleId: string; trophyTitles: TrophyTitle[] }[]` | Individual object for each title returned.`trophyTitles` is [`TrophyTitle`](/api-docs/data-models/trophy-title) type. |
+| Name     | Type                                                   | Description                                                                                                           |
+| :------- | :----------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------- |
+| `titles` | `{ npTitleId: string; trophyTitles: TrophyTitle[] }[]` | Individual object for each title returned.`trophyTitles` is [`TrophyTitle`](/api-docs/data-models/trophy-title) type. |
 
 ### Parameters
 
-| Name            | Type                                                                  | Description                    |
-| :-------------- | :-------------------------------------------------------------------- | :--------------------------------------------------- |
-| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one. |
+| Name            | Type                                                                  | Description                                                                                                                                                                                                                   |
+| :-------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one.                                                                                                    |
 | `accountId`     | `string`                                                              | The account whose title list is being retrieved. Use `"me"` for the authenticating account. To find a user's `accountId`, the [`makeUniversalSearch()`](/api-docs/universal-search#makeuniversalsearch) function can be used. |
-| `options`       | `GetUserTrophiesForSpecificTitleOptions`                                                | search options                                                        |
+| `options`       | `GetUserTrophiesForSpecificTitleOptions`                              | search options                                                                                                                                                                                                                |
 
 ### GetUserTrophiesForSpecificTitleOptions
 
-| Name              | Type                                      |Description                                                                         |
-| :---------------- | :------------------------------------------------------------- | :---------------------------------------------------------------------- |
-| `npTitleIds` | `string` | The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). |
-| `includeNotEarnedTrophyIds` | `boolean` | The response will include the IDs for the individual trophies which have not been earned |
-| `headerOverrides` | [`CallValidHeaders`](/api-docs/data-models/call-valid-headers) | Override the headers in the request to the PSN API, such as to change the language. |
+| Name                        | Type                                                           | Description                                                                                                      |
+| :-------------------------- | :------------------------------------------------------------- | :--------------------------------------------------------------------------------------------------------------- |
+| `npTitleIds`                | `string`                                                       | The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). |
+| `includeNotEarnedTrophyIds` | `boolean`                                                      | The response will include the IDs for the individual trophies which have not been earned                         |
+| `headerOverrides`           | [`CallValidHeaders`](/api-docs/data-models/call-valid-headers) | Override the headers in the request to the PSN API, such as to change the language.                              |
 
 ### Source
 

--- a/website/docs/api-docs/user-trophies.md
+++ b/website/docs/api-docs/user-trophies.md
@@ -253,3 +253,58 @@ const response = await getUserTrophyProfileSummary(authorization, "me");
 ### Source
 
 [trophy/user/getUserTrophyProfileSummary](https://github.com/achievements-app/psn-api/blob/main/src/trophy/user/getUserTrophyProfileSummary.ts)
+
+---
+
+## getUserTrophiesForSpecificTitle
+
+A call to this function will retrieve a summary of the trophies earned by a user for specific titles.
+
+The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). Every title has an ID assigned to it with these typically starting "CUSA" for PS4 titles and "PPSA" for PS5 titles.
+
+The numeric accountId can be that of any PSN account for which the authenticating account has permissions to view the trophy list. When querying the titles associated with the authenticating account the numeric accountId can be substituted with me.
+
+If optional parameter includeNotEarnedTrophyIds is included and set to true then the response will contain a list of IDs for the individual trophies which the user has not earned for each title ID queried. This functionality was added to the endpoint post release, most likely early 2023.
+
+This endpoint can be used as a way of linking the npCommunicationId of a Trophy Set to a titles npTitleId, but as with the other user based endpoints in this version of the API you will only get a useful response back if the account you are querying against has played the title.
+
+**If you attempt to query a title ID which does not exist then a Resource not found error will be returned.**
+
+**There is a limit of 5 title IDs which can be included in the npTitleIds query. Trying to include more than 5 will result in a Bad Request (query: npTitleId) error being returned.**
+
+### Examples
+
+```ts
+import { getUserTrophiesForSpecificTitle } from "psn-api";
+
+const response = await getUserTrophiesForSpecificTitle(authorization, "me", {
+  npTitleIds: 'PPSA13195_00,PPSA27366_00',
+  includeNotEarnedTrophyIds: true
+});
+```
+
+### Returns
+
+| Name             | Type                                                  | Description                                                     |
+| :--------------- | :---------------------------------------------------- | :-------------------------------------------------------------- |
+| `titles`   | `{ npTitleId: string; trophyTitles: TrophyTitle[] }[]` | Individual object for each title returned.`trophyTitles` is [`TrophyTitle`](/api-docs/data-models/trophy-title) type. |
+
+### Parameters
+
+| Name            | Type                                                                  | Description                    |
+| :-------------- | :-------------------------------------------------------------------- | :--------------------------------------------------- |
+| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one. |
+| `accountId`     | `string`                                                              | The account whose title list is being retrieved. Use `"me"` for the authenticating account. To find a user's `accountId`, the [`makeUniversalSearch()`](/api-docs/universal-search#makeuniversalsearch) function can be used. |
+| `options`       | `GetUserTrophiesForSpecificTitleOptions`                                                | search options                                                        |
+
+### GetUserTrophiesForSpecificTitleOptions
+
+| Name              | Type                                      |Description                                                                         |
+| :---------------- | :------------------------------------------------------------- | :---------------------------------------------------------------------- |
+| `npTitleIds` | `string` | The titleId can be a single title ID, or it can be a comma separated list of title IDs (%2C when used in a URL). |
+| `includeNotEarnedTrophyIds` | `boolean` | The response will include the IDs for the individual trophies which have not been earned |
+| `headerOverrides` | [`CallValidHeaders`](/api-docs/data-models/call-valid-headers) | Override the headers in the request to the PSN API, such as to change the language. |
+
+### Source
+
+[trophy/user/getUserTrophiesForSpecificTitle.ts](https://github.com/achievements-app/psn-api/blob/main/src/trophy/user/getUserTrophiesForSpecificTitle.ts)

--- a/website/docs/api-docs/users.md
+++ b/website/docs/api-docs/users.md
@@ -130,17 +130,17 @@ console.log(shareableLink.shareImageUrl); // QR code image URL
 
 ### Returns
 
-| Name                       | Type     | Description                                                                                     |
-| :------------------------- | :------- | :---------------------------------------------------------------------------------------------- |
-| `shareUrl`                 | `string` | The shareable URL for the user's PlayStation profile that can be shared with others.           |
+| Name                       | Type     | Description                                                                                      |
+| :------------------------- | :------- | :----------------------------------------------------------------------------------------------- |
+| `shareUrl`                 | `string` | The shareable URL for the user's PlayStation profile that can be shared with others.             |
 | `shareImageUrl`            | `string` | The URL to a shareable image (QR code) representing the user's profile for social media sharing. |
-| `shareImageUrlDestination` | `string` | The destination URL that the shareable image links to when accessed via the shared image.      |
+| `shareImageUrlDestination` | `string` | The destination URL that the shareable image links to when accessed via the shared image.        |
 
 ### Parameters
 
-| Name            | Type                                                                  | Description                                                                                                                                                                                                                 |
-| :-------------- | :-------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one.                                                                                                  |
+| Name            | Type                                                                  | Description                                                                                                                                                                                                                               |
+| :-------------- | :-------------------------------------------------------------------- | :---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `authorization` | [`AuthorizationPayload`](/api-docs/data-models/authorization-payload) | An object that must contain an `accessToken`. See [this page](/authentication/authenticating-manually) for how to get one.                                                                                                                |
 | `accountId`     | `string`                                                              | The account whose shareable profile link is being retrieved. Use `"me"` for the authenticating account. To find a user's `accountId`, the [`makeUniversalSearch()`](/api-docs/universal-search#makeuniversalsearch) function can be used. |
 
 ### Source


### PR DESCRIPTION
- Add function `getUserTrophiesForSpecificTitle`, which allows querying trophies by specific titleIds. This function can be used as a way of linking the npCommunicationId of a Trophy Set to a titles npTitleId
- Move `nock` from dependencies to devDependencies.